### PR TITLE
Bug fix: output in /settings command is now a file, and potential secrets are stripped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "palconnect"
 authors = ["Lily Ana Valley <hi@lilyvalley.dev>"]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]

--- a/src/commands/admin_commands.rs
+++ b/src/commands/admin_commands.rs
@@ -446,8 +446,8 @@ pub async fn save(ctx: Context<'_>) -> Result<(), Error> {
 // * Values don't have to be lowercase btw, we lowercase them in the code for comparison.
 const SENSITIVE_FIELDS: &[&str] = &[
     "adminpassword", "admin_password", "password", "passwd", "pwd",
-    "secret", "token", "key", "api_key", "apikey",
-    "auth", "authorization", "credential", "cred"
+    "secret", "token", "key", "api", "api_key", "apikey",
+    "auth", "authorization", "credential", "cred", "rcon",
 ];
 
 /// Recursively sanitize sensitive data from JSON values
@@ -460,10 +460,17 @@ fn sanitize_sensitive_data(mut jsonKP: serde_json::Value) -> serde_json::Value {
                 let key_lc = key.to_lowercase();
                 // * Check if the key matches any sensitive field patterns
                 if SENSITIVE_FIELDS.iter().any(|&field| 
+                    
                     key_lc == field ||
+                    
+                    key_lc.starts_with(field) || 
                     key_lc.starts_with(&format!("{}_",&field)) ||
+                    key_lc.starts_with(&format!("{}-",field)) ||
+
                     key_lc.ends_with(&format!("_{}",field)) ||
+                    key_lc.ends_with(&format!("-{}",field)) ||
                     key_lc.ends_with(field)
+
                 ) {
                     // * Stripping the value for sensitive fields
                     *value = serde_json::Value::String("[REDACTED]".to_string());

--- a/src/commands/admin_commands.rs
+++ b/src/commands/admin_commands.rs
@@ -456,13 +456,13 @@ fn sanitize_sensitive_data(mut value: serde_json::Value) -> serde_json::Value {
                 if sensitive_fields.iter().any(|&field| key.to_lowercase().contains(field)) {
                     *val = serde_json::Value::String("[REDACTED]".to_string());
                 } else {
-                    *val = sanitize_sensitive_data(val.clone());
+                    *val = sanitize_sensitive_data(std::mem::take(val));
                 }
             }
         }
         serde_json::Value::Array(arr) => {
             for item in arr.iter_mut() {
-                *item = sanitize_sensitive_data(item.clone());
+                *item = sanitize_sensitive_data(std::mem::take(item));
             }
         }
         _ => {} // Primitives don't need sanitization

--- a/src/commands/admin_commands.rs
+++ b/src/commands/admin_commands.rs
@@ -443,19 +443,33 @@ pub async fn save(ctx: Context<'_>) -> Result<(), Error> {
     Ok(())
 }
 
+// * Values don't have to be lowercase btw, we lowercase them in the code for comparison.
+const SENSITIVE_FIELDS: &[&str] = &[
+    "adminpassword", "admin_password", "password", "passwd", "pwd",
+    "secret", "token", "key", "api_key", "apikey",
+    "auth", "authorization", "credential", "cred"
+];
 
 /// Recursively sanitize sensitive data from JSON values
-fn sanitize_sensitive_data(mut value: serde_json::Value) -> serde_json::Value {
-    match &mut value {
+fn sanitize_sensitive_data(mut jsonKP: serde_json::Value) -> serde_json::Value {
+    match &mut jsonKP {
         serde_json::Value::Object(map) => {
             // List of sensitive field names to redact
-            let sensitive_fields = ["AdminPassword", "admin_password", "password", "secret", "token", "key"];
-            
-            for (key, val) in map.iter_mut() {
-                if sensitive_fields.iter().any(|&field| key.to_lowercase().contains(field)) {
-                    *val = serde_json::Value::String("[REDACTED]".to_string());
+            for (key, value) in map.iter_mut() {
+                // Case-normalized key for comparison
+                let key_lc = key.to_lowercase();
+                // * Check if the key matches any sensitive field patterns
+                if SENSITIVE_FIELDS.iter().any(|&field| 
+                    key_lc == field ||
+                    key_lc.starts_with(&format!("{}_",&field)) ||
+                    key_lc.ends_with(&format!("_{}",field)) ||
+                    key_lc.ends_with(field)
+                ) {
+                    // * Stripping the value for sensitive fields
+                    *value = serde_json::Value::String("[REDACTED]".to_string());
                 } else {
-                    *val = sanitize_sensitive_data(std::mem::take(val));
+                    // * Leaving other values unchanged but sanitizing nested structures
+                    *value = sanitize_sensitive_data(std::mem::take(value));
                 }
             }
         }
@@ -466,5 +480,5 @@ fn sanitize_sensitive_data(mut value: serde_json::Value) -> serde_json::Value {
         }
         _ => {} // Primitives don't need sanitization
     }
-    value
+    jsonKP
 }

--- a/src/commands/admin_commands.rs
+++ b/src/commands/admin_commands.rs
@@ -473,7 +473,7 @@ fn sanitize_sensitive_data(mut jsonKP: serde_json::Value) -> serde_json::Value {
 
                 ) {
                     // * Stripping the value for sensitive fields
-                    *value = serde_json::Value::String("[REDACTED]".to_string());
+                    *value = serde_json::Value::String("▷ REDACTED ◁".to_string());
                 } else {
                     // * Leaving other values unchanged but sanitizing nested structures
                     *value = sanitize_sensitive_data(std::mem::take(value));

--- a/src/commands/admin_commands.rs
+++ b/src/commands/admin_commands.rs
@@ -19,6 +19,7 @@ use serde::Deserialize;
 
 use crate::{Context, Error};
 
+
 #[derive(Debug, Deserialize)]
 struct SettingsResponse {
     #[serde(flatten)]
@@ -50,24 +51,27 @@ pub async fn settings(ctx: Context<'_>) -> Result<(), Error> {
             if response.status().is_success() {
                 match response.json::<SettingsResponse>().await {
                     Ok(settings_data) => {
-                        // Format settings as JSON for better readability
-                        let settings_json = serde_json::to_string_pretty(&settings_data.settings)
-                            .unwrap_or_else(|_| "Failed to format settings".to_string());
 
-                        // Discord has a 1024 character limit for field values
-                        let truncated_settings = if settings_json.len() > 1000 {
-                            format!("{}...\n(truncated)", &settings_json[..1000])
-                        } else {
-                            settings_json
-                        };
+                        // * Admin password is stripped from the output for security reasons.
+                        // Even though the REST API doesn't return it, we double-check here in cases where it may be 
+                        // returned in the future...
+                        let sanitized_settings = sanitize_sensitive_data(settings_data.settings);
 
-                        let embed = serenity::CreateEmbed::new()
-                            .title("⚙️ PalWorld Server Settings")
-                            .description(format!("```json\n{}\n```", truncated_settings))
-                            .color(0x0099ff)
-                            .timestamp(serenity::Timestamp::now());
+                        ctx.send(
+                            poise::CreateReply::default().attachment(
+                                serenity::CreateAttachment::bytes(
+                                    serde_json::to_vec_pretty(&sanitized_settings)
+                                        .map_err(|e| format!("JSON serialization failed: {}", e))
+                                        .unwrap_or_else(|err| {
+                                            eprintln!("Settings serialization error: {}", err);
+                                            format!("Failed to serialize settings: {}", err).into_bytes()
+                                        }),
+                                    "palworld_settings.json",
+                                )
+                            )
+                        )
+                        .await?;
 
-                        ctx.send(poise::CreateReply::default().embed(embed)).await?;
                     }
                     Err(e) => {
                         ctx.send(
@@ -119,8 +123,11 @@ pub async fn metrics(ctx: Context<'_>) -> Result<(), Error> {
             if response.status().is_success() {
                 match response.json::<MetricsResponse>().await {
                     Ok(metrics_data) => {
+                        // Sanitize metrics data as well, in case it contains sensitive information
+                        let sanitized_metrics = sanitize_sensitive_data(metrics_data.metrics);
+                        
                         // Format metrics as JSON for better readability
-                        let metrics_json = serde_json::to_string_pretty(&metrics_data.metrics)
+                        let metrics_json = serde_json::to_string_pretty(&sanitized_metrics)
                             .unwrap_or_else(|_| "Failed to format metrics".to_string());
 
                         // Discord has a 1024 character limit for field values
@@ -435,4 +442,30 @@ pub async fn save(ctx: Context<'_>) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+
+/// Recursively sanitize sensitive data from JSON values
+fn sanitize_sensitive_data(mut value: serde_json::Value) -> serde_json::Value {
+    match &mut value {
+        serde_json::Value::Object(map) => {
+            // List of sensitive field names to redact
+            let sensitive_fields = ["AdminPassword", "admin_password", "password", "secret", "token", "key"];
+            
+            for (key, val) in map.iter_mut() {
+                if sensitive_fields.iter().any(|&field| key.to_lowercase().contains(&field.to_lowercase())) {
+                    *val = serde_json::Value::String("[REDACTED]".to_string());
+                } else {
+                    *val = sanitize_sensitive_data(val.clone());
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                *item = sanitize_sensitive_data(item.clone());
+            }
+        }
+        _ => {} // Primitives don't need sanitization
+    }
+    value
 }

--- a/src/commands/admin_commands.rs
+++ b/src/commands/admin_commands.rs
@@ -453,7 +453,7 @@ fn sanitize_sensitive_data(mut value: serde_json::Value) -> serde_json::Value {
             let sensitive_fields = ["AdminPassword", "admin_password", "password", "secret", "token", "key"];
             
             for (key, val) in map.iter_mut() {
-                if sensitive_fields.iter().any(|&field| key.to_lowercase().contains(&field.to_lowercase())) {
+                if sensitive_fields.iter().any(|&field| key.to_lowercase().contains(field)) {
                     *val = serde_json::Value::String("[REDACTED]".to_string());
                 } else {
                     *val = sanitize_sensitive_data(val.clone());

--- a/src/commands/admin_commands.rs
+++ b/src/commands/admin_commands.rs
@@ -61,7 +61,6 @@ pub async fn settings(ctx: Context<'_>) -> Result<(), Error> {
                             poise::CreateReply::default().attachment(
                                 serenity::CreateAttachment::bytes(
                                     serde_json::to_vec_pretty(&sanitized_settings)
-                                        .map_err(|e| format!("JSON serialization failed: {}", e))
                                         .unwrap_or_else(|err| {
                                             eprintln!("Settings serialization error: {}", err);
                                             format!("Failed to serialize settings: {}", err).into_bytes()


### PR DESCRIPTION
This pull request enhances the security and privacy of server settings and metrics data returned by admin commands. The main improvement is the introduction of a sanitization function that redacts sensitive information (such as passwords and tokens) before displaying or sharing data, and changes how settings are delivered to admins.

### Security and privacy improvements

* Added a new `sanitize_sensitive_data` function that recursively redacts sensitive fields (e.g., passwords, tokens, secrets, keys) from JSON data before it is sent or displayed.
* Updated the `settings` command to use the sanitization function and now delivers server settings as a downloadable JSON file attachment instead of an embedded message, further reducing the risk of exposing sensitive data and improving usability.
* Updated the `metrics` command to sanitize metrics data before formatting and displaying it, ensuring that no sensitive information is leaked in metrics output.

### Code organization

* Added missing `serde::Deserialize` import to support deserialization of settings responses.