### PR TITLE
adds tracing and optional sentry.io integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,10 @@ UPDATES_AUTO_ENABLE=false
 # How often the bot polls the PalWorld server and updates its Discord activity status
 # with the current player count. Minimum recommended: 15 seconds
 STATUS_UPDATE_INTERVAL=30
+
+# Turn on Sentry.IO tracing and crash reporting?
+# This feature is used to report app problems to the developers automatically.
+# If true, turns on telemetry
+# If false, turns off telementry (default)
+# Security, Privacy and Compliance: https://sentry.io/security/
+SENTRYIO_ENABLE=false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,12 @@ cargo-packager = { version = "0.11.7", default-features = false }
 cargo-packager-updater = "0.2.3"
 actix-web = "4.11"
 chrono = "0.4.42"
-log = "0.4.28"
-fern = "0.7"
+tracing = "0.1.44"
+tracing-log = "0.2"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 clap = { version = "4.0", features = ["derive"] }
+sentry = { version = "0.49.1", features = ["tracing"] }
 
 [target.'cfg(unix)'.dependencies]
 syslog = "7.0.0"

--- a/src/commands/about.rs
+++ b/src/commands/about.rs
@@ -15,11 +15,13 @@
 // 
 
 use poise::serenity_prelude as serenity;
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 
 use crate::{Context, Error};
 
 
 /// Show help information
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn about(ctx: Context<'_>) -> Result<(), Error> {
     let embed = serenity::CreateEmbed::new()

--- a/src/commands/admin_commands.rs
+++ b/src/commands/admin_commands.rs
@@ -16,6 +16,7 @@
 
 use poise::serenity_prelude as serenity;
 use serde::Deserialize;
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 
 use crate::{Context, Error};
 
@@ -33,6 +34,7 @@ struct MetricsResponse {
 }
 
 /// Print PalWorld server settings
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn settings(ctx: Context<'_>) -> Result<(), Error> {
     ctx.defer().await?;
@@ -104,6 +106,7 @@ pub async fn settings(ctx: Context<'_>) -> Result<(), Error> {
 }
 
 /// Print PalWorld server metrics
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn metrics(ctx: Context<'_>) -> Result<(), Error> {
     ctx.defer().await?;
@@ -176,6 +179,7 @@ pub async fn metrics(ctx: Context<'_>) -> Result<(), Error> {
 }
 
 /// Announce a message to all players
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn announce(
     ctx: Context<'_>,
@@ -227,6 +231,7 @@ pub async fn announce(
 }
 
 /// Kick a player from the server
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn kick(
     ctx: Context<'_>,
@@ -287,6 +292,7 @@ pub async fn kick(
 }
 
 /// Ban a player from the server
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn ban(
     ctx: Context<'_>,
@@ -347,6 +353,7 @@ pub async fn ban(
 }
 
 /// Unban a previously banned player
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn unban(
     ctx: Context<'_>,
@@ -399,6 +406,7 @@ pub async fn unban(
 
 /// Save the world
 #[poise::command(slash_command)]
+#[instrument(skip(ctx))]
 pub async fn save(ctx: Context<'_>) -> Result<(), Error> {
     ctx.defer().await?;
 
@@ -451,8 +459,9 @@ const SENSITIVE_FIELDS: &[&str] = &[
 ];
 
 /// Recursively sanitize sensitive data from JSON values
-fn sanitize_sensitive_data(mut jsonKP: serde_json::Value) -> serde_json::Value {
-    match &mut jsonKP {
+#[instrument(skip(json_kp))]
+fn sanitize_sensitive_data(mut json_kp: serde_json::Value) -> serde_json::Value {
+    match &mut json_kp {
         serde_json::Value::Object(map) => {
             // List of sensitive field names to redact
             for (key, value) in map.iter_mut() {
@@ -487,5 +496,5 @@ fn sanitize_sensitive_data(mut jsonKP: serde_json::Value) -> serde_json::Value {
         }
         _ => {} // Primitives don't need sanitization
     }
-    jsonKP
+    json_kp
 }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -15,11 +15,13 @@
 // 
 
 use poise::serenity_prelude as serenity;
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 
 use crate::{Context, Error};
 
 
 /// Show help information
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn help(ctx: Context<'_>) -> Result<(), Error> {
     let embed = serenity::CreateEmbed::new()

--- a/src/commands/players.rs
+++ b/src/commands/players.rs
@@ -16,6 +16,7 @@
 
 use poise::serenity_prelude as serenity;
 use serde::Deserialize;
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 
 use crate::{Context, Error};
 
@@ -40,6 +41,7 @@ struct Player {
 }
 
 /// Show current player count on the PalWorld server
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn players(ctx: Context<'_>) -> Result<(), Error> {
     ctx.defer().await?;

--- a/src/commands/server_info.rs
+++ b/src/commands/server_info.rs
@@ -16,7 +16,7 @@
 
 use poise::serenity_prelude as serenity;
 use serde::Deserialize;
-
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 use crate::{Context, Error};
 
 
@@ -29,6 +29,7 @@ struct ServerInfo {
 }
 
 /// Show server information
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn serverinfo(ctx: Context<'_>) -> Result<(), Error> {
     ctx.defer().await?;

--- a/src/commands/start_stop.rs
+++ b/src/commands/start_stop.rs
@@ -15,7 +15,7 @@
 // 
 
 use poise::serenity_prelude::{self as serenity, CreateButton};
-
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 use crate::{Context, Error};
 
 
@@ -24,6 +24,7 @@ const PROMPT_TO_REBOOT: &str = "If you need to restart the server, please stop i
 
 
 /// Start the server
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn start(ctx: Context<'_>) -> Result<(), Error> {
 
@@ -63,6 +64,7 @@ pub async fn start(ctx: Context<'_>) -> Result<(), Error> {
 
 // TODO: Take shortened arguments for time (-t) and message (-m).
 /// Stop the server. May take 2 arguments: --time <seconds> / --message <custom shutdown message>
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn stop(
     ctx: Context<'_>,
@@ -122,6 +124,7 @@ pub async fn stop(
 }
 
 /// Force stop the server
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn forcestop(ctx: Context<'_>) -> Result<(), Error> {
 

--- a/src/commands/test_status.rs
+++ b/src/commands/test_status.rs
@@ -14,10 +14,12 @@
 // <https://www.gnu.org/licenses/>.
 // 
 
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 use crate::{Context, Error};
 use crate::glance::update_status_now;
 
 /// Manually trigger a bot status update (useful for testing)
+#[instrument(skip(ctx))]
 #[poise::command(slash_command)]
 pub async fn update_status(ctx: Context<'_>) -> Result<(), Error> {
     ctx.defer().await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ use std::io::Read;
 use std::env;
 use toml;
 use serde::Deserialize;
-use log::{ trace, debug, info, warn, error };
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 
 
 const CONFIG_LOCATIONS: [&str; 3] = [
@@ -38,6 +38,7 @@ pub struct Config {
     pub heartbeat_port:             Option<u16>,
     pub status_update_interval:     Option<u64>,        // * Status update interval in seconds
     pub logging:                    Option<Logging>,
+    pub sentryio_enabled:           bool
 }
 
 impl Config {
@@ -60,6 +61,7 @@ impl Default for Config {
             heartbeat_port:             None,
             status_update_interval:     None,
             logging:                    None,
+            sentryio_enabled:           false,
         }
     }
 }
@@ -72,6 +74,7 @@ pub struct Logging {
     pub use_file_path: Option<String>,
 }
 
+#[instrument]
 pub fn setup() -> Config {
     
     let mut config_buffer = Vec::new();
@@ -143,6 +146,11 @@ pub fn setup() -> Config {
             panic!("STATUS_UPDATE_INTERVAL must be at least 15 seconds to avoid excessive API polling (got {}).", interval);
         }
         config.status_update_interval = Some(interval);
+    }
+
+    if let Ok(sentryio_enabled) = env::var("SENTRYIO_ENABLE") {
+        config.sentryio_enabled = sentryio_enabled.parse::<bool>()
+            .expect("Failed to parse SENTRYIO_ENABLE as bool");
     }
 
     config

--- a/src/glance.rs
+++ b/src/glance.rs
@@ -14,7 +14,7 @@
 // <https://www.gnu.org/licenses/>.
 // 
 
-use log::{debug, error, info, warn};
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
 use poise::serenity_prelude as serenity;
 use reqwest::Client;
 use serde::Deserialize;
@@ -85,6 +85,7 @@ pub async fn start_status_updater(
 }
 
 /// Update the bot's status with current server information
+#[instrument(skip(ctx, bot_data))]
 async fn update_bot_status(
     ctx: &serenity::Context,
     bot_data: &BotData,
@@ -120,6 +121,7 @@ async fn update_bot_status(
 }
 
 /// Get current player count from the PalWorld server
+#[instrument(skip(http_client, palworld_api_url, admin_password))]
 async fn get_player_count(
     http_client: &Client,
     palworld_api_url: &str,
@@ -140,6 +142,7 @@ async fn get_player_count(
 }
 
 /// Get server information from the PalWorld server
+#[instrument(skip(http_client, palworld_api_url, admin_password))]
 async fn get_server_info(
     http_client: &Client,
     palworld_api_url: &str,
@@ -159,6 +162,7 @@ async fn get_server_info(
 }
 
 /// Manually trigger a status update (useful for testing or immediate updates)
+#[instrument(skip(ctx, bot_data))]
 pub async fn update_status_now(
     ctx: &serenity::Context,
     bot_data: &BotData,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,17 +48,17 @@
 use actix_web::{App, HttpServer};
 use cargo_packager_updater;
 use clap::Parser;
-use fern;
 #[cfg(unix)]
 use fork;
-use log::{debug, error, info, warn};
+use tracing::{ instrument, info, warn, error, debug, trace, trace_span };
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
 use poise::serenity_prelude as serenity;
 use reqwest::Client;
 use std::fs;
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 #[cfg(unix)]
-use syslog;
 use tokio::signal;
 use tokio_util::sync::CancellationToken;
 
@@ -103,7 +103,7 @@ pub struct BotData {
 /// Forks the process into a background daemon, writes a PID file, runs the dispatcher,
 /// and cleans up the PID file on exit.
 #[cfg(unix)]
-async fn handle_daemon_mode() -> Result<(), Error> {
+async fn handle_daemon_mode(config: Config) -> Result<(), Error> {
     info!("👹 Starting in daemon mode...");
     match fork::daemon(false, false) {
         Ok(fork::Fork::Child) => {
@@ -116,7 +116,7 @@ async fn handle_daemon_mode() -> Result<(), Error> {
                 warn!("⚠️ Failed to write PID file: {}", e);
             }
 
-            let result = dispatcher().await;
+            let result = dispatcher(config).await;
 
             // Clean up PID file on exit
             if let Err(e) = remove_pid_file() {
@@ -137,45 +137,79 @@ async fn handle_daemon_mode() -> Result<(), Error> {
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
-    // * Initialize logging first thing (stdout and file on all platforms)
-    fern::Dispatch::new()
-        .format(|out, message, record| {
-            out.finish(format_args!(
-                "{} [{}]: {}",
-                record.level(),
-                chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                message
+fn main() -> Result<(), Error> {
+    // Initialize tracing sinks early so setup/config logs are captured.
+    let file_appender = tracing_appender::rolling::never(".", "log.txt");
+    let (file_writer, file_guard) = tracing_appender::non_blocking(file_appender);
+
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(tracing_subscriber::fmt::layer())
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(file_writer),
+        )
+        .with(sentry::integrations::tracing::layer())
+        .try_init()
+        .map_err(|e| format!("Failed to initialize tracing subscriber: {e}"))?;
+
+    let mut config: Config = Config::default();
+    trace_span!("config setup").in_scope(|| {
+        trace!("🔧 Setting up configuration...");
+        config = setup();
+    });
+
+    let mut _sentry_guard = None;
+    trace_span!("sentry setup").in_scope(|| {
+        _sentry_guard = if config.sentryio_enabled {
+            info!("📡 Telemetry enabled");
+            Some(sentry::init(
+                sentry::ClientOptions::new()
+                .dsn("https://f12475c389b17394817dd9cc7a1cb771@o246148.ingest.us.sentry.io/4511895563862016")
+                .maybe_release(sentry::release_name!())
+                .traces_sample_rate(0.5)
+                .auto_session_tracking(true)
+                .session_mode(sentry::SessionMode::Request)
+                .send_default_pii(false),
             ))
-        })
-        .level(log::LevelFilter::Info)
-        .chain(std::io::stdout())
-        .chain(fern::log_file("log.txt")?)
-        .apply()
-        .expect("Failed to initialize logging");
-
-    info!("🚀 PalConnect starting up...");
-    let args = Args::parse();
-
-    #[cfg(unix)]
-    {
-        info!("🐧 Unix platform detected");
-        if args.daemon {
-            return handle_daemon_mode().await;
         } else {
-            info!("🖥️ Running in foreground mode");
-        }
-    }
+            info!("📡❌ Telemetry disabled");
+            None
+        };
+    });
 
-    dispatcher().await
+    // Keep non-blocking file writer guard alive for the process lifetime.
+    let _file_guard = file_guard;
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+
+            info!("🚀 PalConnect starting up...");
+            let args = Args::parse();
+
+            #[cfg(unix)]
+            {
+                info!("🐧 Unix platform detected");
+                if args.daemon {
+                    return handle_daemon_mode(config).await;
+                } else {
+                    info!("🖥️ Running in foreground mode");
+                }
+            }
+
+            dispatcher(config).await
+
+        })
+
 }
 
-async fn dispatcher() -> Result<(), Error> {
+async fn dispatcher(config: Config) -> Result<(), Error> {
     info!("🔧 Starting main application dispatcher...");
     
-    let config = setup();
-
     // * Check for updates and apply if available
     check_and_install_updates(&config).await;
 
@@ -191,6 +225,7 @@ async fn dispatcher() -> Result<(), Error> {
 
 /// Checks for available updates and installs them if autoupdate is enabled.
 /// Uses cargo-packager-updater to check for new versions and install them.
+#[instrument(skip(config))]
 async fn check_and_install_updates(config: &Config) {
     if config.autoupdate() {
         info!("🔄 Autoupdate enabled, checking online for newer copy...");
@@ -243,7 +278,8 @@ async fn check_and_install_updates(config: &Config) {
 /// and runs the health check server. Handles graceful shutdown on Ctrl+C.
 async fn start_services(
     config: Config,
-    discord_token: String,
+    discord_token: String, // ? Why is this needed when config already contains the token?
+    // TODO: Consider refactoring to avoid passing the token separately if not necessary.
     heartbeat_port: u16,
 ) -> Result<(), Error> {
     // Create cancellation token and JoinHandle storage for graceful shutdown


### PR DESCRIPTION
Replaces `fern` and `log` with `tracing`, a rolling log file implementation and `sentry` for distributed telemetry.

Sentry is default disabled, can be enabled with envs.