### PR TITLE
46 players command fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "palconnect"
 authors = ["Lily Ana Valley <hi@lilyvalley.dev>"]
-version = "0.7.2"
+version = "0.8.1"
 edition = "2024"
 
 [dependencies]

--- a/scripts/mockoon.json
+++ b/scripts/mockoon.json
@@ -1,528 +1,528 @@
 {
-    "uuid": "c635d956-35e8-438e-a5cf-114124a14603",
-    "lastMigration": 33,
-    "name": "PalworldDS",
-    "endpointPrefix": "v1/api",
-    "latency": 0,
-    "port": 3001,
-    "hostname": "",
-    "folders": [],
-    "routes": [
+  "uuid": "c635d956-35e8-438e-a5cf-114124a14603",
+  "lastMigration": 33,
+  "name": "PalworldDS",
+  "endpointPrefix": "v1/api",
+  "latency": 0,
+  "port": 8212,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "f8f3f9d5-baf0-42b7-98d6-a82dfd1ef10b",
+      "type": "http",
+      "documentation": "Server Info",
+      "method": "get",
+      "endpoint": "info",
+      "responses": [
         {
-            "uuid": "f8f3f9d5-baf0-42b7-98d6-a82dfd1ef10b",
-            "type": "http",
-            "documentation": "Server Info",
-            "method": "get",
-            "endpoint": "info",
-            "responses": [
-                {
-                    "uuid": "96ee6962-12ed-42d9-b06b-ab64700abd3f",
-                    "body": "{\n  \"version\": \"v0.0.0\",\n  \"servername\": \"PalWorld Server\",\n  \"description\": \"testing palworld server API\",\n  \"worldguid\": \"615e4c94-abd3-45c2-af5b-9d46889669bc\"\n}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                },
-                {
-                    "uuid": "27824a9e-d9c2-48c4-9c70-c686ed1ac0a0",
-                    "body": "{}",
-                    "latency": 0,
-                    "statusCode": 400,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": false,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
+          "uuid": "96ee6962-12ed-42d9-b06b-ab64700abd3f",
+          "body": "{\n  \"version\": \"v0.0.0\",\n  \"servername\": \"PalWorld Server\",\n  \"description\": \"testing palworld server API\",\n  \"worldguid\": \"615e4c94-abd3-45c2-af5b-9d46889669bc\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
         },
         {
-            "uuid": "268c4e3b-2946-4601-9dce-d567544f917b",
-            "type": "http",
-            "documentation": "Player List",
-            "method": "get",
-            "endpoint": "players",
-            "responses": [
-                {
-                    "uuid": "21598b3a-9bf6-412b-ba34-ca5e4b5261d6",
-                    "body": "{\n  \"players\": [\n    {\n      \"name\": \"Test Player\",\n      \"accountName\": \"testing#1234\",\n      \"playerId\": \"000123\",\n      \"userId\": \"123000\",\n      \"ip\": \"127.0.0.1\",\n      \"ping\": 123,\n      \"location_x\": 0,\n      \"location_y\": 0,\n      \"level\": 1,\n      \"building_count\": 2\n    }\n  ]\n}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "3bc7f3ca-4ff5-4a4d-ab67-2b3d2fc7f9c0",
-            "type": "http",
-            "documentation": "Server Settings",
-            "method": "get",
-            "endpoint": "settings",
-            "responses": [
-                {
-                    "uuid": "c93817de-4ba1-4be9-88d6-1412da502859",
-                    "body": "{\n  \"Difficulty\": \"easy\",\n  \"DayTimeSpeedRate\": 1,\n  \"NightTimeSpeedRate\": 1,\n  \"ExpRate\": 1,\n  \"PalCaptureRate\": 1,\n  \"PalSpawnNumRate\": 1,\n  \"PalDamageRateAttack\": 1,\n  \"PalDamageRateDefense\": 1,\n  \"PlayerDamageRateAttack\": 1,\n  \"PlayerDamageRateDefense\": 1,\n  \"PlayerStomachDecreaseRate\": 1,\n  \"PlayerStaminaDecreaseRate\": 1,\n  \"PlayerAutoHPRegeneRate\": 1,\n  \"PlayerAutoHPRegeneRateInSleep\": 1,\n  \"PalStomachDecreaseRate\": 1,\n  \"PalStaminaDecreaseRate\": 1,\n  \"PalAutoHPRegeneRate\": 1,\n  \"PalAutoHPRegeneRateInSleep\": 1,\n  \"BuildObjectDamageRate\": 1,\n  \"BuildObjectDeteriorationDamageRate\": 1,\n  \"CollectionDropRate\": 1,\n  \"CollectionObjectHpRate\": 1,\n  \"CollectionObjectRespawnSpeedRate\": 1,\n  \"EnemyDropItemRate\": 1,\n  \"DeathPenalty\": \"None\",\n  \"bEnablePlayerToPlayerDamage\": false,\n  \"bEnableFriendlyFire\": false,\n  \"bEnableInvaderEnemy\": false,\n  \"bActiveUNKO\": true,\n  \"bEnableAimAssistPad\": true,\n  \"bEnableAimAssistKeyboard\": false,\n  \"DropItemMaxNum\": 1,\n  \"DropItemMaxNum_UNKO\": 1,\n  \"BaseCampMaxNum\": 4,\n  \"BaseCampWorkerMaxNum\": 32,\n  \"DropItemAliveMaxHours\": 1,\n  \"bAutoResetGuildNoOnlinePlayers\": false,\n  \"AutoResetGuildTimeNoOnlinePlayers\": false,\n  \"GuildPlayerMaxNum\": 32,\n  \"PalEggDefaultHatchTime\": 32,\n  \"WorkSpeedRate\": 1,\n  \"bIsMultiplay\": true,\n  \"bIsPvP\": false,\n  \"bCanPickupOtherGuildDeathPenaltyDrop\": false,\n  \"bEnableNonLoginPenalty\": true,\n  \"bEnableFastTravel\": true,\n  \"bIsStartLocationSelectByMap\": true,\n  \"bEnableDefenseOtherGuildPlayer\": true,\n  \"CoopPlayerMaxNum\": true,\n  \"ServerPlayerMaxNum\": 32,\n  \"ServerName\": \"PalWorld Server\",\n  \"ServerDescription\": \"A PalWorld Server\",\n  \"PublicPort\": 25565,\n  \"PublicIP\": \"127.0.0.1\",\n  \"RCONEnabled\": false,\n  \"RCONPort\": 25566,\n  \"Region\": \"America/Detroit\",\n  \"bUseAuth\": true,\n  \"BanListURL\": \"exmaple.com/bans.txt\",\n  \"RESTAPIEnabled\": true,\n  \"RESTAPIPort\": 80,\n  \"bShowPlayerList\": true,\n  \"AllowConnectPlatform\": \"\",\n  \"bIsUseBackupSaveData\": true,\n  \"LogFormatType\": \"file\"\n}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "48d0aa5d-ee77-4246-88a8-39f0203eca19",
-            "type": "http",
-            "documentation": "Server Metrics",
-            "method": "get",
-            "endpoint": "metrics",
-            "responses": [
-                {
-                    "uuid": "9a1d2bea-462e-4410-a05c-5e83d32d6c86",
-                    "body": "{\n  \"serverfps\": 60,\n  \"currentplayernum\": 1,\n  \"serverframetime\": 100,\n  \"maxplayernum\": 2,\n  \"uptime\": 9600,\n  \"days\": 3\n}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "e61cf9ab-a44c-4d30-9279-74bf45365638",
-            "type": "http",
-            "documentation": "Announce Message",
-            "method": "post",
-            "endpoint": "announce",
-            "responses": [
-                {
-                    "uuid": "233f8617-c4f4-4b8e-8fb5-27cfb73a0584",
-                    "body": "{\n\n}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [
-                        {
-                            "target": "body",
-                            "modifier": "body",
-                            "value": "",
-                            "invert": true,
-                            "operator": "null"
-                        }
-                    ],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "fdfa8871-0f5b-4410-bb0f-ba3f38ed8978",
-            "type": "http",
-            "documentation": "Kick Player",
-            "method": "post",
-            "endpoint": "kick",
-            "responses": [
-                {
-                    "uuid": "a3bc3340-2556-46d8-acf0-7f50a4761933",
-                    "body": "{}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [
-                        {
-                            "target": "body",
-                            "modifier": "userid",
-                            "value": "",
-                            "invert": true,
-                            "operator": "null"
-                        },
-                        {
-                            "target": "body",
-                            "modifier": "message",
-                            "value": "",
-                            "invert": true,
-                            "operator": "null"
-                        }
-                    ],
-                    "rulesOperator": "AND",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "27ceb209-f5dc-4b75-ae3b-af7df3cf0f66",
-            "type": "http",
-            "documentation": "Ban Player",
-            "method": "post",
-            "endpoint": "ban",
-            "responses": [
-                {
-                    "uuid": "f39505bb-b345-4de1-bf2d-3481bed7ac47",
-                    "body": "{}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [
-                        {
-                            "target": "body",
-                            "modifier": "userid",
-                            "value": "",
-                            "invert": true,
-                            "operator": "null"
-                        },
-                        {
-                            "target": "body",
-                            "modifier": "message",
-                            "value": "",
-                            "invert": true,
-                            "operator": "null"
-                        }
-                    ],
-                    "rulesOperator": "AND",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "9d12a4bc-5514-47ef-bd3b-8727d121fbb2",
-            "type": "http",
-            "documentation": "Unban Player",
-            "method": "post",
-            "endpoint": "unban",
-            "responses": [
-                {
-                    "uuid": "6ed2ce73-f065-4976-ba0e-5bcca8c6f484",
-                    "body": "{}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [
-                        {
-                            "target": "body",
-                            "modifier": "userid",
-                            "value": "",
-                            "invert": true,
-                            "operator": "null"
-                        }
-                    ],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "a949ac9b-67c5-4d19-872a-78b59b02e688",
-            "type": "http",
-            "documentation": "Save World",
-            "method": "post",
-            "endpoint": "save",
-            "responses": [
-                {
-                    "uuid": "28ab7492-cc81-40b1-bb6c-367feeb95b45",
-                    "body": "{}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "d24ac3c1-99df-4553-b717-c9c60cfdf997",
-            "type": "http",
-            "documentation": "Shutdown Server",
-            "method": "post",
-            "endpoint": "shutdown",
-            "responses": [
-                {
-                    "uuid": "75c7d387-a9b5-498e-af49-66aa6eb0a62e",
-                    "body": "{}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [
-                        {
-                            "target": "body",
-                            "modifier": "waittime",
-                            "value": "^[0-9]{1,3}$",
-                            "invert": false,
-                            "operator": "regex"
-                        },
-                        {
-                            "target": "body",
-                            "modifier": "message",
-                            "value": "",
-                            "invert": true,
-                            "operator": "null"
-                        }
-                    ],
-                    "rulesOperator": "AND",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
-        },
-        {
-            "uuid": "12dd0ab0-009c-4e6f-b322-e10773c8e6d0",
-            "type": "http",
-            "documentation": "Force Stop Server",
-            "method": "post",
-            "endpoint": "stop",
-            "responses": [
-                {
-                    "uuid": "ef049a26-e80e-42b1-b816-39a2d82c30e1",
-                    "body": "{}",
-                    "latency": 0,
-                    "statusCode": 200,
-                    "label": "",
-                    "headers": [],
-                    "bodyType": "INLINE",
-                    "filePath": "",
-                    "databucketID": "",
-                    "sendFileAsBody": false,
-                    "rules": [],
-                    "rulesOperator": "OR",
-                    "disableTemplating": false,
-                    "fallbackTo404": false,
-                    "default": true,
-                    "crudKey": "id",
-                    "callbacks": []
-                }
-            ],
-            "responseMode": null,
-            "streamingMode": null,
-            "streamingInterval": 0
+          "uuid": "27824a9e-d9c2-48c4-9c70-c686ed1ac0a0",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 400,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
         }
-    ],
-    "rootChildren": [
-        {
-            "type": "route",
-            "uuid": "f8f3f9d5-baf0-42b7-98d6-a82dfd1ef10b"
-        },
-        {
-            "type": "route",
-            "uuid": "268c4e3b-2946-4601-9dce-d567544f917b"
-        },
-        {
-            "type": "route",
-            "uuid": "3bc7f3ca-4ff5-4a4d-ab67-2b3d2fc7f9c0"
-        },
-        {
-            "type": "route",
-            "uuid": "48d0aa5d-ee77-4246-88a8-39f0203eca19"
-        },
-        {
-            "type": "route",
-            "uuid": "e61cf9ab-a44c-4d30-9279-74bf45365638"
-        },
-        {
-            "type": "route",
-            "uuid": "fdfa8871-0f5b-4410-bb0f-ba3f38ed8978"
-        },
-        {
-            "type": "route",
-            "uuid": "27ceb209-f5dc-4b75-ae3b-af7df3cf0f66"
-        },
-        {
-            "type": "route",
-            "uuid": "9d12a4bc-5514-47ef-bd3b-8727d121fbb2"
-        },
-        {
-            "type": "route",
-            "uuid": "a949ac9b-67c5-4d19-872a-78b59b02e688"
-        },
-        {
-            "type": "route",
-            "uuid": "d24ac3c1-99df-4553-b717-c9c60cfdf997"
-        },
-        {
-            "type": "route",
-            "uuid": "12dd0ab0-009c-4e6f-b322-e10773c8e6d0"
-        }
-    ],
-    "proxyMode": false,
-    "proxyHost": "",
-    "proxyRemovePrefix": false,
-    "tlsOptions": {
-        "enabled": false,
-        "type": "CERT",
-        "pfxPath": "",
-        "certPath": "",
-        "keyPath": "",
-        "caPath": "",
-        "passphrase": ""
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
     },
-    "cors": true,
-    "headers": [
+    {
+      "uuid": "268c4e3b-2946-4601-9dce-d567544f917b",
+      "type": "http",
+      "documentation": "Player List",
+      "method": "get",
+      "endpoint": "players",
+      "responses": [
         {
-            "key": "Content-Type",
-            "value": "application/json"
-        },
-        {
-            "key": "Access-Control-Allow-Origin",
-            "value": "*"
-        },
-        {
-            "key": "Access-Control-Allow-Methods",
-            "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
-        },
-        {
-            "key": "Access-Control-Allow-Headers",
-            "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
-        },
-        {
-            "key": "WWW-Authenticate",
-            "value": "Basic realm=\"testing\", charset=\"UTF-8\""
+          "uuid": "21598b3a-9bf6-412b-ba34-ca5e4b5261d6",
+          "body": "{\n  \"players\": [\n    {\n      \"name\": \"Test Player\",\n      \"accountName\": \"testing#1234\",\n      \"playerId\": \"000123\",\n      \"userId\": \"123000\",\n      \"ip\": \"127.0.0.1\",\n      \"ping\": 123,\n      \"location_x\": 0,\n      \"location_y\": 0,\n      \"level\": 1,\n      \"building_count\": 2\n    },\n    {\n      \"name\": \"Another Player\",\n      \"accountName\": \"another#5678\",\n      \"playerId\": \"000456\",\n      \"userId\": \"456000\",\n      \"ip\": \"1.1.1.1\",\n      \"ping\": 42,\n      \"location_x\": 1.0,\n      \"location_y\": 1.0,\n      \"level\": 4,\n      \"building_count\": 0\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
         }
-    ],
-    "proxyReqHeaders": [
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "3bc7f3ca-4ff5-4a4d-ab67-2b3d2fc7f9c0",
+      "type": "http",
+      "documentation": "Server Settings",
+      "method": "get",
+      "endpoint": "settings",
+      "responses": [
         {
-            "key": "",
-            "value": ""
+          "uuid": "c93817de-4ba1-4be9-88d6-1412da502859",
+          "body": "{\n  \"Difficulty\": \"easy\",\n  \"DayTimeSpeedRate\": 1,\n  \"NightTimeSpeedRate\": 1,\n  \"ExpRate\": 1,\n  \"PalCaptureRate\": 1,\n  \"PalSpawnNumRate\": 1,\n  \"PalDamageRateAttack\": 1,\n  \"PalDamageRateDefense\": 1,\n  \"PlayerDamageRateAttack\": 1,\n  \"PlayerDamageRateDefense\": 1,\n  \"PlayerStomachDecreaseRate\": 1,\n  \"PlayerStaminaDecreaseRate\": 1,\n  \"PlayerAutoHPRegeneRate\": 1,\n  \"PlayerAutoHPRegeneRateInSleep\": 1,\n  \"PalStomachDecreaseRate\": 1,\n  \"PalStaminaDecreaseRate\": 1,\n  \"PalAutoHPRegeneRate\": 1,\n  \"PalAutoHPRegeneRateInSleep\": 1,\n  \"BuildObjectDamageRate\": 1,\n  \"BuildObjectDeteriorationDamageRate\": 1,\n  \"CollectionDropRate\": 1,\n  \"CollectionObjectHpRate\": 1,\n  \"CollectionObjectRespawnSpeedRate\": 1,\n  \"EnemyDropItemRate\": 1,\n  \"DeathPenalty\": \"None\",\n  \"bEnablePlayerToPlayerDamage\": false,\n  \"bEnableFriendlyFire\": false,\n  \"bEnableInvaderEnemy\": false,\n  \"bActiveUNKO\": true,\n  \"bEnableAimAssistPad\": true,\n  \"bEnableAimAssistKeyboard\": false,\n  \"DropItemMaxNum\": 1,\n  \"DropItemMaxNum_UNKO\": 1,\n  \"BaseCampMaxNum\": 4,\n  \"BaseCampWorkerMaxNum\": 32,\n  \"DropItemAliveMaxHours\": 1,\n  \"bAutoResetGuildNoOnlinePlayers\": false,\n  \"AutoResetGuildTimeNoOnlinePlayers\": false,\n  \"GuildPlayerMaxNum\": 32,\n  \"PalEggDefaultHatchTime\": 32,\n  \"WorkSpeedRate\": 1,\n  \"bIsMultiplay\": true,\n  \"bIsPvP\": false,\n  \"bCanPickupOtherGuildDeathPenaltyDrop\": false,\n  \"bEnableNonLoginPenalty\": true,\n  \"bEnableFastTravel\": true,\n  \"bIsStartLocationSelectByMap\": true,\n  \"bEnableDefenseOtherGuildPlayer\": true,\n  \"CoopPlayerMaxNum\": true,\n  \"ServerPlayerMaxNum\": 32,\n  \"ServerName\": \"PalWorld Server\",\n  \"ServerDescription\": \"A PalWorld Server\",\n  \"PublicPort\": 25565,\n  \"PublicIP\": \"127.0.0.1\",\n  \"RCONEnabled\": false,\n  \"RCONPort\": 25566,\n  \"Region\": \"America/Detroit\",\n  \"bUseAuth\": true,\n  \"BanListURL\": \"exmaple.com/bans.txt\",\n  \"RESTAPIEnabled\": true,\n  \"RESTAPIPort\": 80,\n  \"bShowPlayerList\": true,\n  \"AllowConnectPlatform\": \"\",\n  \"bIsUseBackupSaveData\": true,\n  \"LogFormatType\": \"file\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
         }
-    ],
-    "proxyResHeaders": [
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "48d0aa5d-ee77-4246-88a8-39f0203eca19",
+      "type": "http",
+      "documentation": "Server Metrics",
+      "method": "get",
+      "endpoint": "metrics",
+      "responses": [
         {
-            "key": "",
-            "value": ""
+          "uuid": "9a1d2bea-462e-4410-a05c-5e83d32d6c86",
+          "body": "{\n  \"serverfps\": 60,\n  \"currentplayernum\": 1,\n  \"serverframetime\": 100,\n  \"maxplayernum\": 2,\n  \"uptime\": 9600,\n  \"days\": 3\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
         }
-    ],
-    "data": [],
-    "callbacks": []
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "e61cf9ab-a44c-4d30-9279-74bf45365638",
+      "type": "http",
+      "documentation": "Announce Message",
+      "method": "post",
+      "endpoint": "announce",
+      "responses": [
+        {
+          "uuid": "233f8617-c4f4-4b8e-8fb5-27cfb73a0584",
+          "body": "{\n\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "body",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "fdfa8871-0f5b-4410-bb0f-ba3f38ed8978",
+      "type": "http",
+      "documentation": "Kick Player",
+      "method": "post",
+      "endpoint": "kick",
+      "responses": [
+        {
+          "uuid": "a3bc3340-2556-46d8-acf0-7f50a4761933",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "userid",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            },
+            {
+              "target": "body",
+              "modifier": "message",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "27ceb209-f5dc-4b75-ae3b-af7df3cf0f66",
+      "type": "http",
+      "documentation": "Ban Player",
+      "method": "post",
+      "endpoint": "ban",
+      "responses": [
+        {
+          "uuid": "f39505bb-b345-4de1-bf2d-3481bed7ac47",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "userid",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            },
+            {
+              "target": "body",
+              "modifier": "message",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "9d12a4bc-5514-47ef-bd3b-8727d121fbb2",
+      "type": "http",
+      "documentation": "Unban Player",
+      "method": "post",
+      "endpoint": "unban",
+      "responses": [
+        {
+          "uuid": "6ed2ce73-f065-4976-ba0e-5bcca8c6f484",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "userid",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "a949ac9b-67c5-4d19-872a-78b59b02e688",
+      "type": "http",
+      "documentation": "Save World",
+      "method": "post",
+      "endpoint": "save",
+      "responses": [
+        {
+          "uuid": "28ab7492-cc81-40b1-bb6c-367feeb95b45",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "d24ac3c1-99df-4553-b717-c9c60cfdf997",
+      "type": "http",
+      "documentation": "Shutdown Server",
+      "method": "post",
+      "endpoint": "shutdown",
+      "responses": [
+        {
+          "uuid": "75c7d387-a9b5-498e-af49-66aa6eb0a62e",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "waittime",
+              "value": "^[0-9]{1,3}$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "body",
+              "modifier": "message",
+              "value": "",
+              "invert": true,
+              "operator": "null"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "12dd0ab0-009c-4e6f-b322-e10773c8e6d0",
+      "type": "http",
+      "documentation": "Force Stop Server",
+      "method": "post",
+      "endpoint": "stop",
+      "responses": [
+        {
+          "uuid": "ef049a26-e80e-42b1-b816-39a2d82c30e1",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "f8f3f9d5-baf0-42b7-98d6-a82dfd1ef10b"
+    },
+    {
+      "type": "route",
+      "uuid": "268c4e3b-2946-4601-9dce-d567544f917b"
+    },
+    {
+      "type": "route",
+      "uuid": "3bc7f3ca-4ff5-4a4d-ab67-2b3d2fc7f9c0"
+    },
+    {
+      "type": "route",
+      "uuid": "48d0aa5d-ee77-4246-88a8-39f0203eca19"
+    },
+    {
+      "type": "route",
+      "uuid": "e61cf9ab-a44c-4d30-9279-74bf45365638"
+    },
+    {
+      "type": "route",
+      "uuid": "fdfa8871-0f5b-4410-bb0f-ba3f38ed8978"
+    },
+    {
+      "type": "route",
+      "uuid": "27ceb209-f5dc-4b75-ae3b-af7df3cf0f66"
+    },
+    {
+      "type": "route",
+      "uuid": "9d12a4bc-5514-47ef-bd3b-8727d121fbb2"
+    },
+    {
+      "type": "route",
+      "uuid": "a949ac9b-67c5-4d19-872a-78b59b02e688"
+    },
+    {
+      "type": "route",
+      "uuid": "d24ac3c1-99df-4553-b717-c9c60cfdf997"
+    },
+    {
+      "type": "route",
+      "uuid": "12dd0ab0-009c-4e6f-b322-e10773c8e6d0"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    },
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "*"
+    },
+    {
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+    },
+    {
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+    },
+    {
+      "key": "WWW-Authenticate",
+      "value": "Basic realm=\"testing\", charset=\"UTF-8\""
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [],
+  "callbacks": []
 }

--- a/src/commands/players.rs
+++ b/src/commands/players.rs
@@ -85,7 +85,7 @@ pub async fn players(ctx: Context<'_>) -> Result<(), Error> {
                             .players
                             .iter()
                             .map(|p| format!(
-                                "{name} \n |---- 🌐 Account: {account} | 🆔 Player: {player_id} \n |---- 🯊 Level: {level} | 🏛 Buildings: {building_count}\n |---- 📍 Location: ({location_x}, {location_y}) | 📶 Ping: {ping}ms\n",
+                                "{name} \n |---- 🌐 Account: {account} | 🆔 Player: {player_id} \n |---- 🯊 Level: {level} | 🏛 Buildings: {building_count} \n |---- 📍 Location: ({location_x}, {location_y}) | 📶 Ping: {ping}ms \n",
                                 name = p.name,
                                 account = p.account_name,
                                 player_id = p.player_id,

--- a/src/commands/players.rs
+++ b/src/commands/players.rs
@@ -28,16 +28,32 @@ struct PlayersResponse {
 
 #[derive(Debug, Deserialize)]
 struct Player {
+
     name: String,
+
+    // * Added post-v1 Palworld update
+    #[serde(rename = "accountName")]
+    account_name: String,
+    
     #[serde(rename = "playerId")]
     player_id: String,
+    
     #[serde(rename = "userId")]
     user_id: String,
-    ip: String,
+    
+    ip: String, // * Currently unused
+    
     ping: f64,
+    
     location_x: f64,
+    
     location_y: f64,
+    
     level: u32,
+
+    // * Added post-v1 Palworld update
+    building_count: u32,
+
 }
 
 /// Show current player count on the PalWorld server
@@ -58,16 +74,30 @@ pub async fn players(ctx: Context<'_>) -> Result<(), Error> {
     {
         Ok(response) => match response.json::<PlayersResponse>().await {
             Ok(players_data) => {
+                debug!("Received /players response, vector length: {}", players_data.players.len());
                 let player_count = players_data.players.len();
                 let player_list = if players_data.players.is_empty() {
                     "No players currently online".to_string()
                 } else {
-                    players_data
-                        .players
-                        .iter()
-                        .map(|p| format!("• {} (Level {})", p.name, p.level))
-                        .collect::<Vec<String>>()
-                        .join("\n")
+                    trace_span!("Formatting player list").in_scope(|| {
+                        debug!("Formatting player list for {} players", player_count);
+                        players_data
+                            .players
+                            .iter()
+                            .map(|p| format!(
+                                "{name} \n |---- 🌐 Account: {account} | 🆔 Player: {player_id} \n |---- 🯊 Level: {level} | 🏛 Buildings: {building_count}\n |---- 📍 Location: ({location_x}, {location_y}) | 📶 Ping: {ping}ms\n",
+                                name = p.name,
+                                account = p.account_name,
+                                player_id = p.player_id,
+                                level = p.level,
+                                building_count = p.building_count,
+                                location_x = p.location_x,
+                                location_y = p.location_y,
+                                ping = p.ping
+                            ))
+                            .collect::<Vec<String>>()
+                            .join("\n")
+                    })
                 };
 
                 let embed = serenity::CreateEmbed::new()
@@ -80,6 +110,7 @@ pub async fn players(ctx: Context<'_>) -> Result<(), Error> {
                 ctx.send(poise::CreateReply::default().embed(embed)).await?;
             }
             Err(e) => {
+                error!("Failed to parse server response: {}", e);
                 ctx.send(
                     poise::CreateReply::default()
                         .content(format!("❌ Failed to parse server response: {}", e))


### PR DESCRIPTION
[PR Description by Autopilot]

This pull request updates the player listing functionality to support additional fields from a recent Palworld update and improves the formatting and logging of player information. The changes affect both the mock API response and the Rust backend that consumes it.

**Player model and API response updates:**

- Added new fields to the `Player` struct (`account_name` and `building_count`) to reflect changes in the Palworld API, and updated field names to match the latest API response.
- Updated the mock API response in `mockoon.json` to include multiple players and the new fields, ensuring the mock data matches the updated backend expectations.

**Formatting and logging improvements:**

- Enhanced the player list formatting in the Discord bot to display more detailed player information, including account name, player ID, level, building count, location, and ping, using a more readable multi-line format.
- Improved logging: added debug statements for received player data and formatting steps, and error logging for failed server response parsing. [[1]](diffhunk://#diff-b62ab63fb04f2a514cbe4beee95fdc7d89083fce23c55ee25b77ad3a79a4462fR77-R100) [[2]](diffhunk://#diff-b62ab63fb04f2a514cbe4beee95fdc7d89083fce23c55ee25b77ad3a79a4462fR113)

**Configuration change:**

- Changed the `mockoon.json` mock server port from `3001` to `8212` to avoid conflicts or for better environment consistency.